### PR TITLE
refactor: Reduce bottom padding across multiple screens for consisten…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,7 +186,7 @@ const AppContent = () => {
   const showBottomNav = currentUser && currentScreen !== 'auth' && currentScreen !== 'userOnboarding' && currentScreen !== 'timer' && currentScreen !== 'conversation'
 
   return (
-    <div className="mobile-container min-h-screen overflow-auto pb-24">
+    <div className="mobile-container min-h-screen overflow-auto">
       {renderScreen()}
       {showBottomNav && (
         <BottomNavigation 

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -19,9 +19,9 @@ export default function BottomNavigation({ currentScreen, onNavigate }: BottomNa
   ]
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-white/95 border-t border-gray-100 backdrop-blur-sm" style={{paddingBottom: 'env(safe-area-inset-bottom)'}}>
+    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-white/95 border-t border-gray-100 backdrop-blur-sm pb-safe" style={{paddingBottom: 'max(1rem, env(safe-area-inset-bottom))'}}>
       <div className="max-w-lg mx-auto px-4">
-        <div className="flex justify-between items-center py-3">
+        <div className="flex justify-between items-center py-2">
           {navItems.map((item) => {
             const Active = currentScreen === item.id
             const Icon = item.Icon
@@ -29,7 +29,7 @@ export default function BottomNavigation({ currentScreen, onNavigate }: BottomNa
               <button
                 key={item.id}
                 onClick={() => onNavigate(item.id)}
-                className="flex flex-col items-center justify-center gap-1 flex-1 py-1"
+                className="flex flex-col items-center justify-center gap-1 flex-1 py-2"
                 aria-current={Active ? 'page' : undefined}
               >
                 <span className={`text-2xl ${Active ? 'text-purple-600' : 'text-gray-400'}`}>

--- a/src/components/exercises/ExerciseLayout.tsx
+++ b/src/components/exercises/ExerciseLayout.tsx
@@ -66,7 +66,7 @@ export const ExerciseLayout = ({
         </header>
 
         {/* Main Content */}
-        <main className="flex-1 px-6 pb-24">{children}</main>
+        <main className="flex-1 px-6 pb-20">{children}</main>
       </div>
     </div>
   );

--- a/src/components/exercises/MindBodySync.tsx
+++ b/src/components/exercises/MindBodySync.tsx
@@ -123,7 +123,7 @@ const MindBodySync = ({ onNavigate }: MindBodySyncProps) => {
       </div>
 
       {/* Main Content */}
-      <div className="flex-1 px-4 pb-24 flex flex-col">
+      <div className="flex-1 px-4 pb-20 flex flex-col">
         {/* Exercise Image */}
         <div className="bg-gradient-to-br from-yellow-400 to-yellow-500 rounded-2xl mb-6 overflow-hidden">
           <img
@@ -171,7 +171,7 @@ const MindBodySync = ({ onNavigate }: MindBodySyncProps) => {
       </div>
 
       {/* Main Content */}
-      <div className="flex-1 px-4 pb-24 flex flex-col items-center justify-center">
+      <div className="flex-1 px-4 pb-20 flex flex-col items-center justify-center">
         {/* Progress */}
         <div className="text-center mb-8">
           <div className="text-2xl font-bold text-gray-900 mb-2">

--- a/src/components/exercises/QuickCalm.tsx
+++ b/src/components/exercises/QuickCalm.tsx
@@ -91,7 +91,7 @@ export const QuickCalm = ({ onNavigate }: QuickCalmProps) => {
   };
 
   return (
-    <div className="min-h-screen bg-white relative pb-32">
+    <div className="min-h-screen bg-white relative pb-20">
       {/* Header */}
       <div className="px-4 pt-12 pb-6">
         <div className="flex items-center space-x-4 mb-4">

--- a/src/components/exercises/StretchAndFocus.tsx
+++ b/src/components/exercises/StretchAndFocus.tsx
@@ -141,7 +141,7 @@ const StretchAndFocus = ({ onNavigate }: StretchAndFocusProps) => {
       </div>
 
       {/* Main Content */}
-      <div className="flex-1 px-4 pb-24">
+      <div className="flex-1 px-4 pb-20">
         {/* Exercise Image */}
         <div className="bg-gray-100 rounded-2xl mb-6 overflow-hidden">
           <img

--- a/src/screens/AICoachScreen.tsx
+++ b/src/screens/AICoachScreen.tsx
@@ -6,7 +6,7 @@ interface AICoachScreenProps {
 
 export default function AICoachScreen({ onNavigate }: AICoachScreenProps) {
   return (
-    <div className="min-h-screen bg-light-bg pb-24">
+    <div className="min-h-screen bg-light-bg pb-20">
       {/* Header */}
       <div className="gradient-bg px-6 pt-12 pb-8 rounded-b-5xl">
         <div className="flex items-center space-x-4 text-white">

--- a/src/screens/AskQuestionScreen.tsx
+++ b/src/screens/AskQuestionScreen.tsx
@@ -104,7 +104,7 @@ export default function AskQuestionScreen({ onNavigate }: AskQuestionScreenProps
   }, [])
 
   return (
-    <div className="min-h-screen bg-gray-50 pb-24">
+    <div className="min-h-screen bg-gray-50 pb-20">
       {/* Header */}
       <div className="px-6 pt-12 pb-6">
         <div className="flex items-center space-x-4">

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -59,7 +59,7 @@ export default function HomeScreen({ onNavigate, user }: HomeScreenProps) {
   ]
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-50 pb-24">
+    <div className="min-h-screen bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-50 pb-20">
       {/* Header with Greeting */}
       <div className="px-6 pt-12 pb-6">
         <div className="text-gray-900">

--- a/src/screens/JournalScreen.tsx
+++ b/src/screens/JournalScreen.tsx
@@ -35,7 +35,7 @@ export default function JournalScreen({ onNavigate, user: _user }: JournalScreen
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 pb-24">
+    <div className="min-h-screen bg-gray-50 pb-20">
       {/* Header */}
       <div className="px-6 pt-12 pb-6">
         <div className="flex items-center space-x-4">

--- a/src/screens/MeditationScreen.tsx
+++ b/src/screens/MeditationScreen.tsx
@@ -92,7 +92,7 @@ const MeditationScreen = ({ onNavigate }: MeditationScreenProps = {}) => {
   };
 
   return (
-    <div className="min-h-screen bg-white relative pb-24">
+    <div className="min-h-screen bg-white relative pb-20">
       {/* Content */}
       <div className="relative">
         {/* Simple Header */}

--- a/src/screens/MidnightRelaxationScreen.tsx
+++ b/src/screens/MidnightRelaxationScreen.tsx
@@ -35,7 +35,7 @@ export default function MidnightRelaxationScreen({ onNavigate }: MidnightRelaxat
   const embedUrl = `https://www.youtube.com/embed/${current.id}`
 
   return (
-    <div className="min-h-screen relative pb-24">
+    <div className="min-h-screen relative pb-20">
       {/* Background */}
       <div className="absolute inset-0 z-0">
         <img

--- a/src/screens/MindCoachScreen.tsx
+++ b/src/screens/MindCoachScreen.tsx
@@ -95,19 +95,19 @@ export default function MindCoachScreen({ onNavigate }: MindCoachScreenProps) {
   }
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="h-screen bg-white overflow-hidden flex flex-col">
       
 
       {/* Header */}
-      <div className="text-center py-4 pb-6">
+      <div className="text-center py-4 pb-6 flex-shrink-0">
         <h1 className="text-black text-lg font-semibold">Mind Coach</h1>
       </div>
 
       {/* Main Video Area - Heygen Avatar will appear here */}
-      <div className="flex-1 px-5 pb-32">
-        <div className="relative mx-auto max-w-sm">
+      <div className="flex-1 px-5 pb-20 overflow-hidden">
+        <div className="relative mx-auto max-w-sm h-full flex items-center justify-center">
           {/* Video Container - Heygen will inject here */}
-          <div className="relative aspect-[3/4] bg-white rounded-3xl overflow-hidden ">
+          <div className="relative aspect-[3/4] bg-white rounded-3xl overflow-hidden max-h-full">
             {/* Fallback content while Heygen loads */}
             <div className="absolute inset-0 bg-white flex items-center justify-center">
               <div className="text-black text-center">
@@ -134,7 +134,7 @@ export default function MindCoachScreen({ onNavigate }: MindCoachScreenProps) {
       </div>
 
       {/* Bottom Controls */}
-      <div className="fixed bottom-24 left-0 right-0">
+      <div className="fixed bottom-20 left-0 right-0 flex-shrink-0">
         <div className="flex items-center justify-center space-x-8 px-8">
           {/* Pause/Resume Button */}
           <button className="w-14 h-14 bg-gray-600 rounded-full flex items-center justify-center shadow-lg">

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -41,7 +41,7 @@ export default function ProfileScreen({ user }: ProfileScreenProps) {
   }
 
   return (
-    <div className="min-h-screen bg-white relative pb-32">
+    <div className="min-h-screen bg-white relative pb-20">
       {/* Header */}
       <div className="px-4 pt-12 pb-6">
         <div className="flex items-center justify-between mb-6">

--- a/src/screens/SharingScreen.tsx
+++ b/src/screens/SharingScreen.tsx
@@ -244,7 +244,7 @@ export default function SharingScreen({ onNavigate: _ }: SharingScreenProps) {
   // Chat interface
   if (selectedChat) {
     return (
-      <div className="min-h-screen bg-white relative pb-32 flex flex-col">
+      <div className="min-h-screen bg-white relative pb-20 flex flex-col">
         {/* Chat Header */}
         <div className="px-4 pt-12 pb-4 border-b border-gray-100">
           <div className="flex items-center space-x-4">
@@ -328,7 +328,7 @@ export default function SharingScreen({ onNavigate: _ }: SharingScreenProps) {
   }
 
   return (
-    <div className="min-h-screen bg-white relative pb-32">
+    <div className="min-h-screen bg-white relative pb-20">
       {/* Header */}
       <div className="px-4 pt-12 pb-6">
         <div className="flex items-center space-x-4 mb-4">

--- a/src/screens/StreaksScreen.tsx
+++ b/src/screens/StreaksScreen.tsx
@@ -65,7 +65,7 @@ export default function StreaksScreen({ onNavigate }: StreaksScreenProps) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 relative pb-24">
+    <div className="min-h-screen bg-gray-50 relative pb-20">
       {/* Header with close X */}
       <div className="flex items-center justify-between p-4 bg-white">
         <button 


### PR DESCRIPTION
This pull request focuses on improving the layout and spacing of the mobile app by standardizing bottom padding across screens and components. The changes ensure a more consistent and visually appealing user experience, especially around the bottom navigation and main content areas.

**Layout and Spacing Consistency**

* Reduced bottom padding from `pb-24`/`pb-32`/`pb-24` to `pb-20` on all major screens (`HomeScreen`, `JournalScreen`, `AskQuestionScreen`, `ProfileScreen`, `SharingScreen`, `StreaksScreen`, `MeditationScreen`, `MidnightRelaxationScreen`, `AICoachScreen`, `MindCoachScreen`, and various exercise components) to create a unified look and avoid excessive whitespace. 
**Bottom Navigation Improvements**

* Updated `BottomNavigation` to use a more flexible and modern padding approach (`pb-safe` and `max(1rem, env(safe-area-inset-bottom))`), and adjusted vertical spacing for navigation items to improve tap targets and visual balance.

**Container and Overflow Adjustments**

* Removed unnecessary bottom padding from the main app container to prevent double-padding with the navigation bar.
* Improved `MindCoachScreen` layout by switching to a flex column structure, ensuring the video area and controls are properly sized and positioned. [[1]](diffhunk://#diff-1e4aba5bafbef77c07b672155ae78f2dcdf913cfd5e54189b6e1a3c641f57beaL98-R110) [[2]](diffhunk://#diff-1e4aba5bafbef77c07b672155ae78f2dcdf913cfd5e54189b6e1a3c641f57beaL137-R137)

These changes collectively provide a cleaner, more consistent interface and improve usability on devices with varying safe area insets.…t layout